### PR TITLE
add alfred-notifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 'use strict';
 const alfy = require('alfy');
+const alfredNotifier = require('alfred-notifier');
+
+alfredNotifier();
 
 // Do not boost exact matches by default, unless specified by the input
 const q = /boost-exact:[^\s]+/.test(alfy.input) ? alfy.input : `${alfy.input} boost-exact:false`;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   ],
   "dependencies": {
     "alfred-link": "^0.1.3",
+    "alfred-notifier": "^0.1.0",
     "alfy": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I was hoping to receive a notification when you released `0.4.0`. Then I released `alfred-notifier` wasn't added yet.