### PR TITLE
:arrow_up: alfy@0.5.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 'use strict';
 const alfy = require('alfy');
-const alfredNotifier = require('alfred-notifier');
-
-alfredNotifier();
 
 // Do not boost exact matches by default, unless specified by the input
 const q = /boost-exact:[^\s]+/.test(alfy.input) ? alfy.input : `${alfy.input} boost-exact:false`;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "xo && ava",
-    "postinstall": "alfred-link"
+    "postinstall": "alfy-init"
   },
   "files": [
     "index.js",
@@ -31,9 +31,7 @@
     "alfy"
   ],
   "dependencies": {
-    "alfred-link": "^0.1.3",
-    "alfred-notifier": "^0.1.0",
-    "alfy": "^0.3.0"
+    "alfy": "^0.5.0"
   },
   "devDependencies": {
     "alfy-test": "^0.3.0",


### PR DESCRIPTION
Bumped `alfy` to `0.5.0` and removed the `alfred-link` and `alfred-notifier` dependencies.