### PR TITLE
Fix subtitle for some package results

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const alfy = require('alfy');
-const dateFormat = require('date-format');
+
+const cmdSubtitle = require('./source/cmd-subtitle');
 
 // Do not boost exact matches by default, unless specified by the input
 const q = /boost-exact:[^\s]+/.test(alfy.input) ? alfy.input : `${alfy.input} boost-exact:false`;
@@ -26,7 +27,7 @@ alfy.fetch('https://api.npms.io/v2/search', {
 						subtitle: 'Open the npm page instead of the GitHub repo'
 					},
 					cmd: {
-						subtitle: `${pkg.version} published at ${dateFormat('yyyy-dd-MM', new Date(pkg.date))} by ${(pkg.author && pkg.author.name) || pkg.publisher.username}`
+						subtitle: cmdSubtitle(pkg)
 					}
 				},
 				quicklookurl: pkg.links.repository && `${pkg.links.repository}#readme`

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "alfy-test": "^0.3.0",
     "ava": "*",
+    "semver-regex": "^2.0.0",
     "xo": "*"
   }
 }

--- a/source/cmd-subtitle.js
+++ b/source/cmd-subtitle.js
@@ -1,0 +1,23 @@
+const dateFormat = require('date-format');
+
+/**
+ * @param {object} pgk - A single package from the npms API
+ * @returns {string} - The command-modifier subtitle for the package
+ */
+const cmdSubtitle = ({author, date, publisher, version}) => {
+	let subtitle = `${version}`;
+
+	if (date) {
+		subtitle += ` published at ${dateFormat('yyyy-dd-MM', new Date(date))}`;
+	}
+
+	if (author) {
+		subtitle += ` by ${(author && author.name)}`;
+	} else if (publisher) {
+		subtitle += ` by ${publisher.username}`;
+	}
+
+	return subtitle;
+};
+
+module.exports = cmdSubtitle;

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import alfyTest from 'alfy-test';
+import semverRegex from 'semver-regex';
 
 test(async t => {
 	const alfy = alfyTest();
@@ -21,4 +22,22 @@ test(async t => {
 		},
 		quicklookurl: 'https://github.com/chalk/chalk#readme'
 	});
+});
+
+test('command-modifier subtitle with date and author', async t => {
+	const alfy = alfyTest();
+
+	const result = await alfy('boost-exact:true chalk');
+	const {subtitle} = result[0].mods.cmd;
+
+	t.regex(subtitle, new RegExp(`${semverRegex().source} published at.*by.*`));
+});
+
+test('command-modifier subtitle without date and author', async t => {
+	const alfy = alfyTest();
+
+	const result = await alfy('boost-exact:true @types/consola');
+	const {subtitle} = result[0].mods.cmd;
+
+	t.regex(subtitle, semverRegex());
 });

--- a/test.js
+++ b/test.js
@@ -4,12 +4,12 @@ import alfyTest from 'alfy-test';
 test(async t => {
 	const alfy = alfyTest();
 
-	const result = await alfy('boost-exact:true chalk');  // Ensure chalk is first
+	const result = await alfy('boost-exact:true chalk'); // Ensure chalk is first
 	delete result[0].mods.cmd;
 
 	t.deepEqual(result[0], {
 		title: 'chalk',
-		subtitle: 'Terminal string styling done right. Much color',
+		subtitle: 'Terminal string styling done right',
 		arg: 'https://github.com/chalk/chalk',
 		mods:
 		{


### PR DESCRIPTION
This fixes a bug I discovered while searching for `consola`.

![screenshot 2018-11-03 22 05 43](https://user-images.githubusercontent.com/4766244/47959231-c3fc4f80-dfb4-11e8-91f6-8cefb0e65640.png)

One of the search results is the `@types/consola` package which is missing `date`, `author`, and `publisher`.

```http
GET https://api.npms.io/v2/search?q=%40types%2Fconsola
```

```json
{
  "total": 1,
  "results": [
    {
      "package": {
        "name": "@types/consola",
        "version": "0.0.0",
        "links": {
          "npm": "https://www.npmjs.com/package/%40types%2Fconsola"
        }
      },
      "score": {
        "final": 0,
        "detail": {
          "quality": 0,
          "popularity": 0,
          "maintenance": 0
        }
      },
      "searchScore": 100000
    }
  ]
}
```

I also included a commit which fixes the existing test.